### PR TITLE
Add Instructions to Download Data and Update Snakefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,25 @@ snakemake -j 1 prepare_postprocessing
 ```
 This will automatically execute the prerequisite rule `retrieve_result_networks`. Once completed, you will have all the required data to analyze the `plot_marginal_prices.ipynb` and `plot_summary.ipynb` notebooks.
 
-## Handling Errors
+## ⚠️ Handling Download Errors
 
-The current framework for downloading network files is under development and may have connections/permissions issues. If you face them, just manually download the files using the link provided in the `Snakefile` and place them in the parent folder. The rest of the Snakemake workflow should work as expected.
+The current framework for downloading network files is still under development and may encounter connection or permission issues. If you experience such problems, you can manually download the required files using the instructions below. Once placed correctly, the rest of the Snakemake workflow should function as expected. 
+
+If you're familiar with Snakemake, you may also refer to the Snakefile for a deeper understanding of the workflow and file dependencies.
+
+### ✅ Solved Hydrogen Networks
+
+1. Download the `solved_h2.zip` file from this [link](https://zenodo.org/records/16945007).
+2. Extract the contents.
+3. Move the extracted `solved_h2` folder into the `networks/` directory.  
+    *(If the `networks/` directory does not exist, you may need to create it.)*
+
+### ✅ Post-Processing Results Networks
+
+1. Download the `.zip` file from this [link](https://zenodo.org/records/17129490).
+2. Extract the contents.
+3. Move the extracted `AP2_pypsa_earth_results` folder into the `results/` directory.
+    *(If the `results/` directory does not exist, you may need to create it.)*
 
 ## Results - Dashboard
 

--- a/Snakefile
+++ b/Snakefile
@@ -4,20 +4,21 @@ rule retrieve_h2_networks:
     threads: 1
     shell:
         """
+        mkdir -p networks
         curl --progress-bar -X GET https://zenodo.org/records/16945007/files/solved_h2.zip?download=1 > networks/solved_h2.zip
         unzip networks/solved_h2.zip -d networks/
         rm -rf networks/solved_h2.zip
         """
 
-rule retrieve_results_networks:
+rule retrieve_AP2_results_networks:
     output:
-        results = directory("results/")
+        results = directory("results/AP2_pypsa_earth_results")
     threads: 1
     shell:
         """
-        curl --progress-bar -X GET https://zenodo.org/records/16945238/files/results.zip?download=1 > results.zip
-        unzip results.zip -d ./
-        rm -rf ./results.zip
+        curl --progress-bar -X GET https://zenodo.org/records/17129490/files/AP2_pypsa_earth_results.zip?download=1 > AP2_pypsa_earth_results.zip
+        unzip AP2_pypsa_earth_results.zip -d ./results
+        rm -rf ./AP2_pypsa_earth_results.zip
         """
 
 rule retrieve_configs:
@@ -36,7 +37,7 @@ rule retrieve_configs:
 
 rule prepare_postprocessing:
     input:
-        results = directory("results/"),
+        results = directory("results/AP2_pypsa_earth_results"),
         configs = directory("configs")
     output:
         touch("./.postprocess_done")
@@ -47,6 +48,4 @@ rule prepare_postprocessing:
 rule all:
     input:
         "networks/solved_h2",
-        "results/",
-        "./.postprocess_done",
-        "configs/"
+        "./.postprocess_done"

--- a/Snakefile
+++ b/Snakefile
@@ -12,13 +12,16 @@ rule retrieve_h2_networks:
 
 rule retrieve_AP2_results_networks:
     output:
-        results = directory("results/AP2_pypsa_earth_results")
+        touch(".AP2_results_done")
     threads: 1
     shell:
         """
-        curl --progress-bar -X GET https://zenodo.org/records/17129490/files/AP2_pypsa_earth_results.zip?download=1 > AP2_pypsa_earth_results.zip
-        unzip AP2_pypsa_earth_results.zip -d ./results
-        rm -rf ./AP2_pypsa_earth_results.zip
+        set -e
+        mkdir -p results
+        curl -fL --progress-bar https://zenodo.org/records/17129490/files/AP2_pypsa_earth_results.zip?download=1 -o AP2_pypsa_earth_results.zip 
+        unzip -q AP2_pypsa_earth_results.zip -d results
+        mv results/AP2_pypsa_earth_results/* results/ || true
+        rm -rf AP2_pypsa_earth_results.zip results/AP2_pypsa_earth_results
         """
 
 rule retrieve_configs:
@@ -27,7 +30,7 @@ rule retrieve_configs:
     threads: 1
     shell:
         """
-        curl -fL https://github.com/doneachh/pypsa-earth/archive/refs/heads/h2g-a.zip -o "repo.zip"
+        curl -fL --progress-bar https://github.com/doneachh/pypsa-earth/archive/refs/heads/h2g-a.zip -o "repo.zip"
         unzip -q "./repo.zip" "pypsa-earth-h2g-a/configs/*" -d ./
         rm -rf ./repo.zip
         mkdir -p ./configs
@@ -37,10 +40,10 @@ rule retrieve_configs:
 
 rule prepare_postprocessing:
     input:
-        results = directory("results/AP2_pypsa_earth_results"),
+        ".AP2_results_done",
         configs = directory("configs")
     output:
-        touch("./.postprocess_done")
+        touch(".postprocess_done")
     threads: 1
     script:
         "scripts/make_stats_dicts.py"
@@ -48,4 +51,5 @@ rule prepare_postprocessing:
 rule all:
     input:
         "networks/solved_h2",
-        "./.postprocess_done"
+        ".AP2_results_done",
+        ".postprocess_done"


### PR DESCRIPTION
- [ ] Update README for users to download data manually in case Snakemake does not work.
- [ ] Upload the entire AP2_pypsa_earth_results to Zenodo and update the link in Snakefile.
- [ ] Change the Snakefile to a more comprehensive structure.